### PR TITLE
Added SSL Pinning

### DIFF
--- a/PocketSocket/PSWebSocket.h
+++ b/PocketSocket/PSWebSocket.h
@@ -141,3 +141,21 @@ typedef NS_ENUM(NSInteger, PSWebSocketReadyState) {
 - (void)setStreamProperty:(CFTypeRef)property forKey:(NSString *)key;
 
 @end
+
+/**
+ *  NSURLRequest
+ */
+@interface NSURLRequest (PinnedCertificates)
+
+@property (nonatomic, copy, readonly) NSArray *ps_pinnedCertificates;
+
+@end
+
+/**
+ *  NSMutableURLRequest
+ */
+@interface NSMutableURLRequest (PinnedCertificates)
+
+@property (nonatomic, copy) NSArray *ps_pinnedCertificates;
+
+@end

--- a/PocketSocket/PSWebSocket.m
+++ b/PocketSocket/PSWebSocket.m
@@ -35,6 +35,7 @@
     BOOL _failed;
     BOOL _pumpingInput;
     BOOL _pumpingOutput;
+    BOOL _pinnedCertificateValidated;
     NSInteger _closeCode;
     NSString *_closeReason;
     NSMutableArray *_pingHandlers;
@@ -129,12 +130,16 @@
             
             opts[(__bridge id)kCFStreamSSLLevel] = (__bridge id)kCFStreamSocketSecurityLevelNegotiatedSSL;
             
-            // @TODO PINNED SSL
+            if ([request ps_pinnedCertificates].count != 0) {
+                opts[(__bridge id)kCFStreamSSLValidatesCertificateChain] = @NO;
+            }
             
 #if DEBUG
+            _pinnedCertificateValidated = YES;
             opts[(__bridge id)kCFStreamSSLValidatesCertificateChain] = @NO;
             NSLog(@"PSWebSocket: debug mode allowing all SSL certificates");
 #endif
+
             [_outputStream setProperty:opts forKey:(__bridge id)kCFStreamPropertySSLSettings];
         }
 	}
@@ -477,7 +482,37 @@
 #pragma mark - NSStreamDelegate
 
 - (void)stream:(NSStream *)stream handleEvent:(NSStreamEvent)event {
-    // @TODO HANDLE PINNED SSL CERTIFICATES
+    if (_secure && !_pinnedCertificateValidated && (event == NSStreamEventHasBytesAvailable || event == NSStreamEventHasSpaceAvailable)) {
+        NSArray *pinnedCertificates = [_request ps_pinnedCertificates];
+
+        if (pinnedCertificates) {
+            SecTrustRef secTrust = (__bridge SecTrustRef)[stream propertyForKey:(__bridge id)kCFStreamPropertySSLPeerTrust];
+
+            if (secTrust) {
+                NSInteger certificateCount = SecTrustGetCertificateCount(secTrust);
+
+                for (NSInteger i = 0; i < certificateCount && !_pinnedCertificateValidated; ++i) {
+                    SecCertificateRef certificate = SecTrustGetCertificateAtIndex(secTrust, i);
+                    NSData *certificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
+
+                    for (NSData *localCertificateData in pinnedCertificates) {
+                        if ([localCertificateData isEqualToData:certificateData]) {
+                            _pinnedCertificateValidated = YES;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (!_pinnedCertificateValidated) {
+                NSString *reason = @"Pinned SSL certificate could not be validated";
+                NSError *error = [NSError errorWithDomain:PSWebSocketErrorDomain code:PSWebSocketErrorCodeInvalidCertificate userInfo:@{NSLocalizedDescriptionKey: reason}];
+                [self failWithError:error];
+                return;
+            }
+        }
+    }
+
     [self executeWork:^{
         switch(event) {
             case NSStreamEventOpenCompleted: {
@@ -573,6 +608,29 @@
 
 - (void)dealloc {
     [self disconnect];
+}
+
+@end
+
+@implementation  NSURLRequest (CertificateAdditions)
+
+- (NSArray *)ps_pinnedCertificates;
+{
+    return [NSURLProtocol propertyForKey:@"ps_pinnedCertificates" inRequest:self];
+}
+
+@end
+
+@implementation  NSMutableURLRequest (CertificateAdditions)
+
+- (NSArray *)ps_pinnedCertificates;
+{
+    return [NSURLProtocol propertyForKey:@"ps_pinnedCertificates" inRequest:self];
+}
+
+- (void)setPs_pinnedCertificates:(NSArray *)ps_pinnedCertificates;
+{
+    [NSURLProtocol setProperty:ps_pinnedCertificates forKey:@"ps_pinnedCertificates" inRequest:self];
 }
 
 @end

--- a/PocketSocket/PSWebSocketTypes.h
+++ b/PocketSocket/PSWebSocketTypes.h
@@ -23,7 +23,8 @@ typedef NS_ENUM(NSInteger, PSWebSocketErrorCodes) {
     PSWebSocketErrorCodeUnknown = 0,
     PSWebSocketErrorCodeTimedOut,
     PSWebSocketErrorCodeHandshakeFailed,
-    PSWebSocketErrorCodeConnectionFailed
+    PSWebSocketErrorCodeConnectionFailed,
+    PSWebSocketErrorCodeInvalidCertificate
 };
 
 typedef NS_ENUM(NSInteger, PSWebSocketStatusCode) {


### PR DESCRIPTION
`ps_pinnedCertificates` is expected to be an `NSArray` of `NSData` objects containing the certificate file data.

Credit to [SocketRocket](https://github.com/square/SocketRocket) and [Jon Flanders](http://www.jonflanders.com/?p=1415), whose code served as a basis for this implementation.